### PR TITLE
Serve index.html for root requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,15 @@
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200
+
+# Ensure the root of the domain loads the SPA entry point
+[[redirects]]
+  from = "/"
+  to = "/index.html"
+  status = 200
+
+# Fallback for any other route so the SPA can handle navigation
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/nginx.conf
+++ b/nginx.conf
@@ -36,6 +36,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Ensure the root path immediately serves the index file
+    location = / {
+        try_files /index.html =404;
+    }
+
     # Static assets cache
     location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
## Summary
- ensure the HTTPS nginx server explicitly serves index.html when the root path is requested
- add Netlify redirects so the domain root and any other routes load the SPA entry point

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68daa53c0378832d8b526b9e0a31a1a6