### PR TITLE
Adjust hero spacing for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,19 +1021,27 @@
             .intro-title {
                 font-size: 2rem;
             }
-            
+
             .intro-subtitle {
                 font-size: 1rem;
                 letter-spacing: 1px;
             }
-            
+
             .intro-logo {
                 width: 100px;
                 height: 100px;
             }
-            
+
             .intro-loading {
                 width: 200px;
+            }
+
+            .hero {
+                padding: 5rem 1.25rem 2.5rem;
+            }
+
+            .hero-badge {
+                margin-top: 0;
             }
         }
 
@@ -1220,13 +1228,14 @@
             }
 
             .hero {
-                padding: 10rem 1.5rem 3rem;
+                padding: 6rem 1.5rem 3rem;
                 min-height: auto;
             }
 
             .hero-badge {
                 font-size: 0.8rem;
                 padding: 0.4rem 1.2rem;
+                margin-top: 0;
                 margin-bottom: 1.5rem;
             }
 


### PR DESCRIPTION
## Summary
- reduce the hero section's top padding on tablets and phones so the heading appears sooner on smaller screens
- remove the large top margin from the hero badge within mobile breakpoints to bring it closer to the title

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa95d6104832d8e67fa123888eea1